### PR TITLE
RMI Sampler Fixes/Optimizations

### DIFF
--- a/src/com/orangeandbronze/tools/jmeter/RMIRemoteObjectConfig.java
+++ b/src/com/orangeandbronze/tools/jmeter/RMIRemoteObjectConfig.java
@@ -39,7 +39,7 @@ public class RMIRemoteObjectConfig
     public static final String TARGET_RMI_NAME = "RmiRemoteObjectConfig.target_rmi_name";
     public static final String REMOTE_INSTANCES = "RMIRemoteObject.instances";
 
-    private static Log log = LogFactory.getLog(RMISampler.class);
+    private static Log log = LogFactory.getLog(RMIRemoteObjectConfig.class);
 
     /**
      * Creates a new <code>RMIRemoteObjectConfig</code> instance.

--- a/src/com/orangeandbronze/tools/jmeter/RMIRemoteObjectConfig.java
+++ b/src/com/orangeandbronze/tools/jmeter/RMIRemoteObjectConfig.java
@@ -130,7 +130,7 @@ public class RMIRemoteObjectConfig
         @Override
         public String registerRmiInstance(final String key, final Remote instance)
             throws RemoteException {
-            log.info("Register: " + key);
+            log.debug("Register: " + key);
             registerInstanceAtKey(key, instance);
             return key;
         }

--- a/src/com/orangeandbronze/tools/jmeter/RMISampler.java
+++ b/src/com/orangeandbronze/tools/jmeter/RMISampler.java
@@ -177,6 +177,7 @@ public class RMISampler
     protected SampleResult sample() {
         log.debug("Sample called");
         RMISampleResult res = new RMISampleResult();
+        res.sampleStart();
 
         RMIRemoteObjectConfig remoteObj = getRemoteObjectConfig();
 
@@ -203,7 +204,7 @@ public class RMISampler
 
             // Assume success
             res.setSuccessful(true);
-            res.sampleStart();
+            res.latencyEnd();
             Object retval = m.invoke(target, args);
 
             res.sampleEnd();

--- a/src/com/orangeandbronze/tools/jmeter/RMISampler.java
+++ b/src/com/orangeandbronze/tools/jmeter/RMISampler.java
@@ -97,8 +97,6 @@ public class RMISampler
     }
 
     public void testEnded(final String host) {
-        JMeterContext jmctx = JMeterContextService.getContext();
-        jmctx.getVariables().remove(BSH_INTERPRETER);
     }
 
     public void setTargetName(final String value) {

--- a/src/com/orangeandbronze/tools/jmeter/RMISampler.java
+++ b/src/com/orangeandbronze/tools/jmeter/RMISampler.java
@@ -88,7 +88,7 @@ public class RMISampler
             argInterpreter.eval(getArgumentsScript());
         }
         catch(EvalError evalErr) {
-            log.info("Error initially evaluating script: " + evalErr.getMessage());
+            log.warn("Error initially evaluating script: " + evalErr.getMessage());
         }
     }
 
@@ -167,25 +167,25 @@ public class RMISampler
             return (Object[]) argInterpreter.eval("methodArgs();");
         }
         catch(EvalError evalErr) {
-            log.info(getMethodName() + ": Error evaluating script: " + evalErr.getMessage() + "; argInterpreter = " + argInterpreter);
-            evalErr.printStackTrace();
+            log.error(getMethodName() + ": Error evaluating script: " + evalErr.getMessage() + "; argInterpreter = " + argInterpreter,
+                      evalErr);
         }
 
         return null;
     }
 
     protected SampleResult sample() {
-        log.info("Sample called");
+        log.debug("Sample called");
         RMISampleResult res = new RMISampleResult();
 
         RMIRemoteObjectConfig remoteObj = getRemoteObjectConfig();
 
         String methodName = getMethodName();
 
-        log.info("Getting arguments");
+        log.debug("Getting arguments");
         Object[] args = getArguments();
 
-        log.info("Getting target");
+        log.debug("Getting target");
         String targetName = getTargetName();
         Remote target = remoteObj.getTarget(targetName);
 

--- a/src/com/orangeandbronze/tools/jmeter/RMISampler.java
+++ b/src/com/orangeandbronze/tools/jmeter/RMISampler.java
@@ -183,6 +183,7 @@ public class RMISampler
 
         log.debug("Getting arguments");
         Object[] args = getArguments();
+        res.connectEnd();
 
         log.debug("Getting target");
         String targetName = getTargetName();


### PR DESCRIPTION
A bunch of micro-optimizations on the RMI Sampler. These aren't empirical in any way, shape, or form — I do have anecdotal data that shows some improvement from these.

Also included are a small set of concurrency fixes, particularly with regards to the remote registry.