### PR TITLE
Tag method args script with an ID.

### DIFF
--- a/src/com/orangeandbronze/tools/jmeter/ProxyObjectGraph.java
+++ b/src/com/orangeandbronze/tools/jmeter/ProxyObjectGraph.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import static com.orangeandbronze.tools.jmeter.util.InstanceHandleFactory.buildInstanceName;
+import static com.orangeandbronze.tools.jmeter.util.UniqueNameFactory.buildInstanceName;
 import static com.orangeandbronze.tools.jmeter.util.ReflectionUtil.getFieldsUpTo;
 
 

--- a/src/com/orangeandbronze/tools/jmeter/impl/RmiSamplerGeneratorMethodRecorder.java
+++ b/src/com/orangeandbronze/tools/jmeter/impl/RmiSamplerGeneratorMethodRecorder.java
@@ -24,6 +24,8 @@ import com.orangeandbronze.tools.jmeter.util.ScriptletGenerator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import static com.orangeandbronze.tools.jmeter.util.UniqueNameFactory.generateKeyForMethod;
+
 /**
  * Describe class RmiSamplerGeneratorMethodRecorder here.
  *
@@ -79,8 +81,12 @@ public class RmiSamplerGeneratorMethodRecorder
         }
 
         ScriptletGenerator gen = new ScriptletGenerator();
+        String genKey = generateKeyForMethod(record);
 
         StringBuilder sb = new StringBuilder();
+        sb.append("// $Tag '");
+        sb.append(genKey);
+        sb.append("'\n");
         sb.append("setAccessibility(true);\nmethodArgs ( ) {\n");
         for(int i = 0; i < args.length; i++) {
             if(args[i] == null) {

--- a/src/com/orangeandbronze/tools/jmeter/util/UniqueNameFactory.java
+++ b/src/com/orangeandbronze/tools/jmeter/util/UniqueNameFactory.java
@@ -1,11 +1,41 @@
 package com.orangeandbronze.tools.jmeter.util;
 
 import java.rmi.Remote;
+import java.util.Base64;
+import java.util.UUID;
+
+import com.orangeandbronze.tools.jmeter.MethodCallRecord;
 
 public class UniqueNameFactory {
 
     public static final String buildInstanceName(Remote instance) {
         int stubHashCode = instance.hashCode();
         return "remote_I" + stubHashCode;
+    }
+
+    public static String encodeLongLongAsBase64(final long msb, final long lsb) {
+        byte[] b = new byte[16];
+        long v = msb;
+        for (int i = 0; i < 8; i++) {
+            b[i] = (byte) (v & 0xff);
+            v = v >>> 8;
+        }
+        v = lsb;
+        for (int i = 0; i < 8; i++) {
+            b[i + 8] = (byte) (v & 0xff);
+            v = v >>> 8;
+        }
+
+        String rawBase64 = Base64.getUrlEncoder().encodeToString(b);
+        return rawBase64.substring(0, rawBase64.length() - 2);
+    }
+
+    public static String generateKeyForMethod(final MethodCallRecord r) {
+        // Use UUIDv4 as a way to generate unique keys, encoded as base 64
+        UUID id = UUID.randomUUID();
+        long msb = id.getMostSignificantBits();
+        long lsb = id.getLeastSignificantBits();
+
+        return encodeLongLongAsBase64(msb, lsb);
     }
 }

--- a/src/com/orangeandbronze/tools/jmeter/util/UniqueNameFactory.java
+++ b/src/com/orangeandbronze/tools/jmeter/util/UniqueNameFactory.java
@@ -2,7 +2,7 @@ package com.orangeandbronze.tools.jmeter.util;
 
 import java.rmi.Remote;
 
-public class InstanceHandleFactory {
+public class UniqueNameFactory {
 
     public static final String buildInstanceName(Remote instance) {
         int stubHashCode = instance.hashCode();

--- a/test/com/orangeandbronze/tools/jmeter/util/UniqueNameFactoryTest.java
+++ b/test/com/orangeandbronze/tools/jmeter/util/UniqueNameFactoryTest.java
@@ -1,0 +1,15 @@
+package com.orangeandbronze.tools.jmeter.util;
+
+import junit.framework.TestCase;
+
+public class UniqueNameFactoryTest extends TestCase {
+
+    public void testEncodeLongLongAsBase64()
+        throws Exception {
+        long msb = 0x12345678L;
+        long lsb = 0x9ABCDEF0L;
+
+        String encoded = UniqueNameFactory.encodeLongLongAsBase64(msb, lsb);
+        assertEquals("eFY0EgAAAADw3ryaAAAAAA", encoded);
+    }
+}


### PR DESCRIPTION
Generate a unique ID for each method scriptlet, added in as a comment on the first line. This is useful for debugging BeanShell evaluation errors in the scriptlet, as when we log evaluation errors, the error message contains an ellipsized first line. Having the tag allows users to search for the relevant samplers, even with multiple samplers against the same method.