### PR TITLE
Annotate scriptlet variables with type info.

### DIFF
--- a/src/com/jmibanez/tools/jmeter/impl/RmiSamplerGeneratorMethodRecorder.java
+++ b/src/com/jmibanez/tools/jmeter/impl/RmiSamplerGeneratorMethodRecorder.java
@@ -88,19 +88,22 @@ public class RmiSamplerGeneratorMethodRecorder
         sb.append(genKey);
         sb.append("'\n");
         sb.append("setAccessibility(true);\nmethodArgs ( ) {\n");
+
+        String[] argVarnames = new String[args.length];
         for(int i = 0; i < args.length; i++) {
             if(args[i] == null) {
                 continue;
             }
 
-            sb.append(gen.generateScriptletForObject(args[i], "args" + i, argTypes[i]));
+            argVarnames[i] = gen.getVariableNameForType(args[i]) + i;
+            sb.append(gen.generateScriptletForObject(args[i], argVarnames[i],
+                                                     argTypes[i]));
         }
 
         sb.append("Object[] args = new Object[] { ");
         for(int i = 0; i < args.length; i++) {
             if(args[i] != null) {
-                sb.append("args");
-                sb.append(i);
+                sb.append(argVarnames[i]);
             }
             else {
                 sb.append("null");

--- a/src/com/jmibanez/tools/jmeter/util/ScriptletGenerator.java
+++ b/src/com/jmibanez/tools/jmeter/util/ScriptletGenerator.java
@@ -16,10 +16,12 @@ import java.beans.IntrospectionException;
 import java.util.Collection;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Properties;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -287,7 +289,11 @@ public class ScriptletGenerator {
 
         String[] scr = scriptletFromFields(bean, varname);
         decl.append("\n");
-        decl.append("// ----------  Field values\n");
+        decl.append("// ----------  Field values for ");
+        decl.append(beanType.getSimpleName());
+        decl.append(" ");
+        decl.append(varname);
+        decl.append("\n");
         decl.append(scr[0]);
 
         scriptlet.append("\n");
@@ -418,9 +424,12 @@ public class ScriptletGenerator {
             return unpackPrimitiveArray(varname, arrayBean, elementType);
         }
 
+        String[] elementVarnames = new String[arrLen];
         for(int i = 0; i < arrLen; i++) {
             Object o = Array.get(arrayBean, i);
-            String[] eScriptlet = scriptletForObject(varname + "_element" + i, o,
+            elementVarnames[i] = varname + "_element" + i + "_"
+                + getVariableNameForType(o);
+            String[] eScriptlet = scriptletForObject(elementVarnames[i], o,
                                                      elementType);
             if(!eScriptlet[0].equals("")) {
                 elementScr.append(eScriptlet[0]);
@@ -438,9 +447,7 @@ public class ScriptletGenerator {
         arrayScr.append(elementType.getCanonicalName());
         arrayScr.append("[] { ");
         for(int i = 0; i < arrLen; i++) {
-            arrayScr.append(varname);
-            arrayScr.append("_element");
-            arrayScr.append(i);
+            arrayScr.append(elementVarnames[i]);
             if(i != arrLen - 1) {
                 arrayScr.append(", ");
             }
@@ -465,13 +472,18 @@ public class ScriptletGenerator {
         }
 
         int i = 0;
+        List<String> elementVarnames = new ArrayList<>();
         for(Iterator ii = c.iterator(); ii.hasNext(); ) {
             Object o = ii.next();
-            String[] eScriptlet = scriptletForObject(varname + "_element" + i, o, Object.class);
+            String elementVarname = varname + "_element" + i + "_"
+                + getVariableNameForType(o);
+            elementVarnames.add(elementVarname);
+            String[] eScriptlet = scriptletForObject(elementVarname, o,
+                                                     Object.class);
             if(!eScriptlet[0].equals("")) {
                 elementScr.append(eScriptlet[0]);
             }
-            
+
             if(!eScriptlet[1].equals("")) {
                 cScr.append(eScriptlet[1]);
             }
@@ -487,16 +499,12 @@ public class ScriptletGenerator {
         cScr.append("();\n");
 
 
-        i = 0;
-        for(Iterator ii = c.iterator(); ii.hasNext(); ) {
-            ii.next();
+        for(Iterator<String> ii = elementVarnames.iterator(); ii.hasNext(); ) {
+            String elementVarname = ii.next();
             cScr.append(varname);
             cScr.append(".add(");
-            cScr.append(varname);
-            cScr.append("_element");
-            cScr.append(i);
+            cScr.append(elementVarname);
             cScr.append(");\n");
-            i++;
         }
 
         return new String[] { elementScr.toString(), cScr.toString() };

--- a/src/com/jmibanez/tools/jmeter/util/ScriptletGenerator.java
+++ b/src/com/jmibanez/tools/jmeter/util/ScriptletGenerator.java
@@ -50,6 +50,22 @@ public class ScriptletGenerator {
         return scriptletAndDecl[0] + "\n// -------------------------------\n\n" + scriptletAndDecl[1];
     }
 
+    public String getVariableNameForType(final Object bean) {
+        if(bean == null) {
+            return "args";
+        }
+
+        Class<?> beanClass = bean.getClass();
+        String className = beanClass.getSimpleName();
+
+        if(beanClass.isArray()) {
+            Class<?> elementClass = beanClass.getComponentType();
+            className = elementClass.getSimpleName() + "Array";
+        }
+
+        return Introspector.decapitalize(className);
+    }
+
     private String[] scriptletFromIntrospection(Object bean, String varname)
         throws IntrospectionException {
         StringBuilder decl = new StringBuilder();

--- a/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
+++ b/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
@@ -71,7 +71,7 @@ public class ScriptletGeneratorTest extends TestCase {
 
         List l = new ArrayList();
         l.add(simple);
-        
+
         SimpleBeanInstance simple2 = new SimpleBeanInstance();
         simple2.setName("Simple\nString with \"quotes\" and a \0 null");
         simple2.setAge(42);
@@ -270,6 +270,20 @@ public class ScriptletGeneratorTest extends TestCase {
         for (int i = 0; i < testArr.length; i++) {
             assertEquals(testArr[i], fromBsh[i]);
         }
+    }
+
+    public void testGetVariableNameForType()
+        throws Exception {
+        assertEquals("args", inst.getVariableNameForType(null));
+
+        assertEquals("simpleBeanInstance",
+                     inst.getVariableNameForType(new SimpleBeanInstance()));
+        assertEquals("arrayList",
+                     inst.getVariableNameForType(new ArrayList<Object>()));
+        assertEquals("objectArray",
+                     inst.getVariableNameForType(new Object[0]));
+        assertEquals("intArray",
+                     inst.getVariableNameForType(new int[0]));
     }
 
 

--- a/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
+++ b/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
@@ -178,6 +178,47 @@ public class ScriptletGeneratorTest extends TestCase {
         }
     }
 
+    public void testGenerateScriptletForList()
+        throws Exception {
+        SimpleBeanInstance a = new SimpleBeanInstance();
+        a.setName("Simple\nString with \"quotes\" and a \0 null (A)");
+        a.setAge(40);
+        a.c = '\n';
+
+        SimpleBeanInstance b = new SimpleBeanInstance();
+        b.setName("Simple\nString with \"quotes\" and a \0 null (B)");
+        b.setAge(41);
+        b.c = '\t';
+
+        SimpleBeanInstance c = new SimpleBeanInstance();
+        c.setName("Simple\nString with \"quotes\" and a \0 null (C)");
+        c.setAge(42);
+        c.c = '?';
+
+        List<SimpleBeanInstance> testList = new ArrayList<>();
+        testList.add(a);
+        testList.add(b);
+        testList.add(c);
+
+        String scriptlet = inst.generateScriptletForObject(testList, "list");
+
+        assertNotNull(scriptlet);
+        System.out.println(scriptlet);
+
+        bshInterpreter.eval(scriptlet);
+        Object listFromBsh = bshInterpreter.get("list");
+        Class<?> listFromBshClass = listFromBsh.getClass();
+
+        assertTrue(List.class.isAssignableFrom(listFromBshClass));
+
+        // No way to recover collection element types, unfortunately
+        List fromBsh = (List) listFromBsh;
+        assertEquals(testList.size(), fromBsh.size());
+        for (int i = 0; i < testList.size(); i++) {
+            assertEquals(testList.get(i), fromBsh.get(i));
+        }
+    }
+
     public void testGenerateScriptletForArrayWithProperType()
         throws Exception {
         SimpleBeanInstance a = new SimpleBeanInstance();


### PR DESCRIPTION
Add class names to the generated scriptlet variable names, to make it easier to associate variables with corresponding classes. This makes the variable names longer and more verbose, but allows users to infer that e.g. a particular variable is for a field name belonging to a particular object/class. For instance:

```
   String arr_element2_name = "Simple\nString with \"quotes\" and a \u0000 null (C)";
```

becomes

```
   String arr_element2_simpleBeanInstance_name = "Simple\nString with \"quotes\" and a \u0000 null (C)";
```

and so on, making it explicit that the name is a field of a `SimpleBeanInstance`.