### PR TITLE
Sampler sent bytes

### DIFF
--- a/src/com/jmibanez/tools/jmeter/MethodCallRecord.java
+++ b/src/com/jmibanez/tools/jmeter/MethodCallRecord.java
@@ -1,14 +1,16 @@
 package com.jmibanez.tools.jmeter;
 
 import java.lang.reflect.Method;
-import java.io.Serializable;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectOutputStream;
 import java.io.IOException;
-import java.io.ByteArrayInputStream;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
+
+import static com.jmibanez.tools.jmeter.util.ArgumentsUtil.packArgs;
+import static com.jmibanez.tools.jmeter.util.ArgumentsUtil.unpackArgs;
+
 
 public class MethodCallRecord
     implements Serializable
@@ -36,7 +38,7 @@ public class MethodCallRecord
         this.argTypes = m.getParameterTypes();
         this.method = constructMethodName(m.getName(), this.argTypes);
         this.args = args;
-        packArgs();
+        this.argsPacked = packArgs(this.args);
     }
 
     public String getTarget() {
@@ -48,7 +50,7 @@ public class MethodCallRecord
     }
 
     public Object[] recreateArguments() {
-        unpackArgs();
+        this.args = unpackArgs(this.argsPacked);
         return args;
     }
 
@@ -167,33 +169,7 @@ public class MethodCallRecord
             throw new IllegalStateException("Invalid state in input stream: End of stream not found");
         }
 
-        unpackArgs();
-    }
-
-    private void packArgs() {
-        try {
-            ByteArrayOutputStream packOut = new ByteArrayOutputStream();
-            ObjectOutputStream ostream = new ObjectOutputStream(packOut);
-            ostream.writeObject(args);
-            argsPacked = packOut.toByteArray();
-        }
-        catch(IOException ign) {
-            throw new RuntimeException(ign);
-        }
-    }
-
-    private void unpackArgs() {
-        try {
-            ByteArrayInputStream packIn = new ByteArrayInputStream(argsPacked);
-            ObjectInputStream istream = new ObjectInputStream(packIn);
-            args = (Object[]) istream.readObject();
-        }
-        catch(IOException ign) {
-            throw new RuntimeException(ign);
-        }
-        catch(ClassNotFoundException cnfe) {
-            throw new RuntimeException(cnfe);
-        }
+        this.args = unpackArgs(this.argsPacked);
     }
 }
 

--- a/src/com/jmibanez/tools/jmeter/RMISampler.java
+++ b/src/com/jmibanez/tools/jmeter/RMISampler.java
@@ -28,6 +28,9 @@ import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 
+import static com.jmibanez.tools.jmeter.util.ArgumentsUtil.packArgs;
+import static com.jmibanez.tools.jmeter.util.ArgumentsUtil.unpackArgs;
+
 /**
  * Describe class RMISampler here.
  *
@@ -173,6 +176,18 @@ public class RMISampler
 
         log.debug("Getting arguments");
         Object[] args = getArguments();
+
+        // Pack and then unpack args, so we can safely measure
+        // serialized argument size
+        try {
+            byte[] argsPacked = packArgs(args);
+            args = unpackArgs(argsPacked);
+            res.setSentBytes(argsPacked.length);
+        }
+        catch (Exception packErr) {
+            log.warn(getMethodName() + ": Couldn't pack/unpack arguments to measure sent size: " + packErr.getMessage(),
+                     packErr);
+        }
         res.connectEnd();
 
         log.debug("Getting target");

--- a/src/com/jmibanez/tools/jmeter/util/ArgumentsUtil.java
+++ b/src/com/jmibanez/tools/jmeter/util/ArgumentsUtil.java
@@ -4,8 +4,14 @@
  * See README in the source tree for more info
  *
  */
- 
+
 package com.jmibanez.tools.jmeter.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
 
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.control.TransactionSampler;
@@ -29,6 +35,32 @@ public class ArgumentsUtil {
     private ArgumentsUtil() {
     }
 
+
+    public static byte[] packArgs(final Object[] args) {
+        try {
+            ByteArrayOutputStream packOut = new ByteArrayOutputStream();
+            ObjectOutputStream ostream = new ObjectOutputStream(packOut);
+            ostream.writeObject(args);
+            return packOut.toByteArray();
+        }
+        catch(IOException ign) {
+            throw new RuntimeException(ign);
+        }
+    }
+
+    public static Object[] unpackArgs(final byte[] argsPacked) {
+        try {
+            ByteArrayInputStream packIn = new ByteArrayInputStream(argsPacked);
+            ObjectInputStream istream = new ObjectInputStream(packIn);
+            return (Object[]) istream.readObject();
+        }
+        catch(IOException ign) {
+            throw new RuntimeException(ign);
+        }
+        catch(ClassNotFoundException cnfe) {
+            throw new RuntimeException(cnfe);
+        }
+    }
 
     public static void setArguments(Sampler s, Object[] args) {
         if(s instanceof TransactionSampler) {


### PR DESCRIPTION
Record RMI argument size by packing and unpacking (i.e. serializing/deserializing) the method argument list, to avoid any stateful side effects in the arguments' serialization logic.