### PR TITLE
Bugfix: Broken copy from GUI of RMI Sampler nodes

### DIFF
--- a/src/com/jmibanez/tools/jmeter/RMISampler.java
+++ b/src/com/jmibanez/tools/jmeter/RMISampler.java
@@ -55,7 +55,7 @@ public class RMISampler
     private static Log log = LogFactory.getLog(RMISampler.class);
 
 
-    private ThreadLocal<Interpreter> interpreter = new ThreadLocal<Interpreter>();
+    private transient ThreadLocal<Interpreter> interpreter = new ThreadLocal<Interpreter>();
 
     /**
      * Creates a new <code>RMISampler</code> instance.


### PR DESCRIPTION
To implement copying of nodes, JMeter serializes test elements — `ThreadLocal`s are not serializable, so we get a non-fatal error when trying to copy RMI samplers.

Mark the thread local as transient so it doesn't get serialized; the copy gets a new `ThreadLocal` anyway.