### PR TITLE
Replace loggers with commons-logging.

### DIFF
--- a/src/com/jmibanez/tools/jmeter/DynamicStubProxyInvocationHandler.java
+++ b/src/com/jmibanez/tools/jmeter/DynamicStubProxyInvocationHandler.java
@@ -2,7 +2,6 @@ package com.jmibanez.tools.jmeter;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
-import org.apache.log.Logger;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;

--- a/src/com/jmibanez/tools/jmeter/NativeRmiProxy.java
+++ b/src/com/jmibanez/tools/jmeter/NativeRmiProxy.java
@@ -27,13 +27,11 @@ import java.rmi.registry.Registry;
 import java.util.HashMap;
 import java.util.Map;
 
-//import org.apache.log4j.Logger;
-import org.apache.log.Logger;
-
 import com.jmibanez.tools.jmeter.impl.SimpleLoggingMethodRecorder;
 import com.jmibanez.tools.jmeter.impl.NullMethodRecorder;
 import java.rmi.server.UnicastRemoteObject;
-import org.apache.jorphan.logging.LoggingManager;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.util.BeanShellInterpreter;
 import org.apache.jorphan.util.JMeterException;
@@ -65,7 +63,7 @@ public class NativeRmiProxy
     private int serverPort;
 
     private volatile boolean stillRunning;
-    private static Logger log = LoggingManager.getLoggerForClass(); // Logger.getLogger(NativeRmiProxy.class);
+    private static Log log = LogFactory.getLog(NativeRmiProxy.class);
 
     private MethodRecorder recorder;
 

--- a/src/com/jmibanez/tools/jmeter/NativeRmiProxyController.java
+++ b/src/com/jmibanez/tools/jmeter/NativeRmiProxyController.java
@@ -11,19 +11,18 @@ import org.apache.jmeter.control.GenericController;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.protocol.http.control.RecordingController;
 import org.apache.jmeter.testelement.WorkBench;
-import org.apache.log.Logger;
-//import org.apache.log4j.Logger;
 import org.apache.jmeter.gui.tree.JMeterTreeModel;
 import org.apache.jmeter.gui.GuiPackage;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.jmeter.exceptions.IllegalUserActionException;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.testelement.property.IntegerProperty;
 import com.jmibanez.tools.jmeter.gui.NativeRmiProxyControllerGui;
 import com.jmibanez.tools.jmeter.impl.RmiSamplerGeneratorMethodRecorder;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jmeter.extractor.BeanShellPostProcessor;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.modifiers.BeanShellPreProcessor;
@@ -57,7 +56,7 @@ public class NativeRmiProxyController extends GenericController {
 
     public static final String BINDING_SCRIPT = "RmiProxy.binding_script";
 
-    private static Logger log = LoggingManager.getLoggerForClass(); // Logger.getLogger(NativeRmiProxyController.class);
+    private static Log log = LogFactory.getLog(NativeRmiProxyController.class);
 
     private JMeterTreeNode target;
 


### PR DESCRIPTION
This cleans up the deprecation notices, due to JMeter 3.2 transitioning to a different logging framework; we just use commons-logging all throughout.