### PR TITLE
Scriptlet Generation: Skip non-serializables.

### DIFF
--- a/src/com/jmibanez/tools/jmeter/util/ScriptletGenerator.java
+++ b/src/com/jmibanez/tools/jmeter/util/ScriptletGenerator.java
@@ -9,14 +9,15 @@ package com.jmibanez.tools.jmeter.util;
 
 import java.beans.BeanInfo;
 import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Field;
 import java.beans.Introspector;
 import java.beans.IntrospectionException;
-import java.util.Collection;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -167,9 +168,17 @@ public class ScriptletGenerator {
                 continue;
             }
 
+            Class<?> valType = f.getType();
+
+            if (Object.class.isAssignableFrom(valType)
+                && !Collection.class.isAssignableFrom(valType)
+                && !Serializable.class.isAssignableFrom(valType)) {
+                // Skip non-Serializable values
+                continue;
+            }
+
             f.setAccessible(true);
 
-            Class valType = f.getType();
             Object val = null;
             try {
                 val = f.get(bean);

--- a/src/com/jmibanez/tools/jmeter/util/ScriptletGenerator.java
+++ b/src/com/jmibanez/tools/jmeter/util/ScriptletGenerator.java
@@ -163,8 +163,9 @@ public class ScriptletGenerator {
         int objCount = 1;
         for(Field f: getFieldsUpTo(beanClass, Object.class)) {
             if (Modifier.isFinal(f.getModifiers())
-                || Modifier.isStatic(f.getModifiers())) {
-                // Ignore static or final fields
+                || Modifier.isStatic(f.getModifiers())
+                || Modifier.isTransient(f.getModifiers())) {
+                // Ignore transient, static, or final fields
                 continue;
             }
 

--- a/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
+++ b/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
@@ -336,6 +336,7 @@ public class ScriptletGeneratorTest extends TestCase {
         SimpleBeanInstance simple = new SimpleBeanInstance();
         simple.setName("Simple\nString with \"quotes\" and a \0 null");
         simple.setAge(42);
+        simple.setMemory(100);
         simple.c = '\n';
 
         simple.setIntern(new NonSerializable());
@@ -353,6 +354,10 @@ public class ScriptletGeneratorTest extends TestCase {
         // Ensure that intern is null;
         assertNotNull(simple.getIntern());
         assertNull(fromScriptlet.getIntern());
+
+        // Ensure memory wasn't set
+        assertEquals(100, simple.getMemory());
+        assertEquals(0, fromScriptlet.getMemory());
     }
 
 
@@ -363,6 +368,7 @@ public class ScriptletGeneratorTest extends TestCase {
         private int age;
 
         private NonSerializable intern;
+        private transient int memory;
 
         public char c;
 
@@ -382,6 +388,14 @@ public class ScriptletGeneratorTest extends TestCase {
         }
         public void setAge(int argAge) {
             this.age = argAge;
+        }
+
+        public int getMemory() {
+            return this.memory;
+        }
+
+        public void setMemory(int memory) {
+            this.memory = memory;
         }
 
         public NonSerializable getIntern() {

--- a/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
+++ b/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
@@ -7,11 +7,14 @@
  
 package com.jmibanez.tools.jmeter.util;
 
-import junit.framework.TestCase;
-import bsh.Interpreter;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
+
+import junit.framework.TestCase;
+import bsh.Interpreter;
+
 
 /**
  * Describe class ScriptletGeneratorTest here.
@@ -43,7 +46,7 @@ public class ScriptletGeneratorTest extends TestCase {
     }
 
 
-    public void testSimpleGenerateScriptletForObject() 
+    public void testSimpleGenerateScriptletForObject()
         throws Exception {
 
         SimpleBeanInstance simple = new SimpleBeanInstance();
@@ -327,12 +330,39 @@ public class ScriptletGeneratorTest extends TestCase {
                      inst.getVariableNameForType(new int[0]));
     }
 
+    public void testSkipNonSerializableValues()
+        throws Exception {
+
+        SimpleBeanInstance simple = new SimpleBeanInstance();
+        simple.setName("Simple\nString with \"quotes\" and a \0 null");
+        simple.setAge(42);
+        simple.c = '\n';
+
+        simple.setIntern(new NonSerializable());
+
+        String scriptlet = inst.generateScriptletForObject(simple, "simple");
+
+        assertNotNull(scriptlet);
+        System.out.println(scriptlet);
+
+        bshInterpreter.eval(scriptlet);
+
+        SimpleBeanInstance fromScriptlet = (SimpleBeanInstance) bshInterpreter.get("simple");
+        assertEquals(simple, fromScriptlet);
+
+        // Ensure that intern is null;
+        assertNotNull(simple.getIntern());
+        assertNull(fromScriptlet.getIntern());
+    }
+
 
     public static class SimpleBeanInstance
-    {
+        implements Serializable {
 
         private String name;
         private int age;
+
+        private NonSerializable intern;
 
         public char c;
 
@@ -354,6 +384,14 @@ public class ScriptletGeneratorTest extends TestCase {
             this.age = argAge;
         }
 
+        public NonSerializable getIntern() {
+            return this.intern;
+        }
+
+        public void setIntern(NonSerializable intern) {
+            this.intern = intern;
+        }
+
         @Override
         public boolean equals(Object other) {
             if(!(other instanceof SimpleBeanInstance)) {
@@ -370,7 +408,7 @@ public class ScriptletGeneratorTest extends TestCase {
 
 
     public static class ComplexBeanInstance
-    {
+        implements Serializable {
         private List personList;
         private Map someMap;
 
@@ -416,7 +454,7 @@ public class ScriptletGeneratorTest extends TestCase {
     }
 
     public static class CyclicClass
-    {
+        implements Serializable {
         public List<CyclicClassChild> children = new ArrayList<CyclicClassChild>();
 
         @Override
@@ -431,7 +469,7 @@ public class ScriptletGeneratorTest extends TestCase {
     }
 
     public static class CyclicClassChild
-    {
+        implements Serializable {
         public CyclicClass parent;
         public String name;
 
@@ -442,6 +480,18 @@ public class ScriptletGeneratorTest extends TestCase {
 
             CyclicClassChild otherCyclicClassChild = (CyclicClassChild) other;
             return (name == null && otherCyclicClassChild.name == null) || name.equals(otherCyclicClassChild.name);
+        }
+    }
+
+    public static class NonSerializable {
+        private int key = 69;
+
+        public int getKey() {
+            return key;
+        }
+
+        public void setKey(final int key) {
+            this.key = key;
         }
     }
 }


### PR DESCRIPTION
Skip generating scriptlets for values which shouldn't be serialized anyway, such as objects which don't implement `java.io.Serializable` or `java.io.Externalizable`, or transient fields. This may affect some users, as they may have custom serialization logic that breaks this assumption (e.g. they have a `writeObject` method that writes out transient fields).