### PR TITLE
When necessary, construct argument objects via Objenesis.

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -65,6 +65,11 @@
         rev="3.2.5"
         conf="production" />
     <dependency
+        org="org.objenesis"
+        name="objenesis"
+        rev="2.6"
+        conf="production" />
+    <dependency
         org="junit"
         name="junit"
         rev="4.11"

--- a/src/com/jmibanez/tools/jmeter/RMIRemoteObjectConfig.java
+++ b/src/com/jmibanez/tools/jmeter/RMIRemoteObjectConfig.java
@@ -23,6 +23,9 @@ import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+
 /**
  * Describe class RMIRemoteObjectConfig here.
  *
@@ -37,6 +40,7 @@ public class RMIRemoteObjectConfig
     implements ThreadListener {
 
     public static final String TARGET_RMI_NAME = "RmiRemoteObjectConfig.target_rmi_name";
+    public static final String OBJENESIS_FACTORY = "RMIRemoteObject.factory";
     public static final String REMOTE_INSTANCES = "RMIRemoteObject.instances";
 
     private static Log log = LogFactory.getLog(RMIRemoteObjectConfig.class);
@@ -67,15 +71,27 @@ public class RMIRemoteObjectConfig
 
     public void threadStarted() {
         log.info("Configuring remote stub registry for thread");
-        RemoteRegistry registry = new RemoteRegistry();
+
         JMeterContext jmctx = JMeterContextService.getContext();
         if(jmctx.getVariables().getObject(REMOTE_INSTANCES) != null) {
             log.fatal("Thread context already has a registry???", new Throwable());
         }
+        RemoteRegistry registry = new RemoteRegistry();
         jmctx.getVariables().putObject(REMOTE_INSTANCES, registry);
+
+        Objenesis objenesis = new ObjenesisStd();
+        if(jmctx.getVariables().getObject(OBJENESIS_FACTORY) != null) {
+            log.fatal("Thread context already has an Objenesis Factory???", new Throwable());
+        }
+        jmctx.getVariables().putObject(OBJENESIS_FACTORY, objenesis);
     }
 
     public void threadFinished() {
+    }
+
+    public Objenesis getFactory() {
+        JMeterContext jmctx = JMeterContextService.getContext();
+        return (Objenesis) jmctx.getVariables().getObject(OBJENESIS_FACTORY);
     }
 
     public Remote getTarget(final String targetName) {

--- a/src/com/jmibanez/tools/jmeter/util/ReflectionUtil.java
+++ b/src/com/jmibanez/tools/jmeter/util/ReflectionUtil.java
@@ -5,6 +5,15 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+import org.objenesis.instantiator.ObjectInstantiator;
+
+import static com.jmibanez.tools.jmeter.RMIRemoteObjectConfig.OBJENESIS_FACTORY;
+
 public class ReflectionUtil {
 
     public static List<Field> getFieldsUpTo(Class<?> startClass,
@@ -22,5 +31,18 @@ public class ReflectionUtil {
         }
 
         return currentClassFields;
+    }
+
+    public static <T> T newInstance(Class<T> clazz) {
+        JMeterContext jmctx = JMeterContextService.getContext();
+        Objenesis objenesis = null;
+        if (jmctx.getVariables() != null) {
+            objenesis = (Objenesis) jmctx.getVariables().getObject(OBJENESIS_FACTORY);
+        }
+        else {
+            objenesis = new ObjenesisStd();
+        }
+        ObjectInstantiator factory = objenesis.getInstantiatorOf(clazz);
+        return (T) factory.newInstance();
     }
 }

--- a/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
+++ b/test/com/jmibanez/tools/jmeter/util/ScriptletGeneratorTest.java
@@ -65,6 +65,33 @@ public class ScriptletGeneratorTest extends TestCase {
 
     }
 
+    public void testGenerateScriptletForClassWithoutDefaultConstructor()
+        throws Exception {
+
+        SimpleBeanInstance simple = new SimpleBeanInstance();
+        simple.setName("Simple\nString with \"quotes\" and a \0 null");
+        simple.setAge(42);
+        simple.c = '\n';
+
+        SerializableBeanWithoutDefaultConstructor bean
+            = new SerializableBeanWithoutDefaultConstructor(simple);
+
+        String scriptlet = inst.generateScriptletForObject(bean, "noCons");
+
+        assertNotNull(scriptlet);
+
+        bshInterpreter.eval(scriptlet);
+
+        SerializableBeanWithoutDefaultConstructor fromScriptlet
+            = (SerializableBeanWithoutDefaultConstructor) bshInterpreter.get("noCons");
+        assertNotNull(fromScriptlet);
+
+        SimpleBeanInstance simpleFromScriptlet = fromScriptlet.getOther();
+        assertNotNull(simpleFromScriptlet);
+        assertEquals(simple, simpleFromScriptlet);
+
+    }
+
     public void testNestedGenerateScriptletForObject()
         throws Exception {
         SimpleBeanInstance simple = new SimpleBeanInstance();
@@ -417,6 +444,24 @@ public class ScriptletGeneratorTest extends TestCase {
             return name.equals(otherBean.name)
                 && age == otherBean.age
                 && c == otherBean.c;
+        }
+    }
+
+
+    public static class SerializableBeanWithoutDefaultConstructor
+        implements Serializable {
+
+        private SimpleBeanInstance other;
+
+        public SerializableBeanWithoutDefaultConstructor(SimpleBeanInstance other) {
+            this.other = other;
+        }
+
+        public final SimpleBeanInstance getOther() {
+            return this.other;
+        }
+        public final void setOther(final SimpleBeanInstance argOther) {
+            this.other = argOther;
         }
     }
 


### PR DESCRIPTION
If any of the captured objects don't have default constructors, it would be best to use Objenesis to construct them, similar to how serializable objects are reconstructed; to try to avoid any overhead from using Objenesis, we only do this when necessary, instead of for all objects.