### PR TITLE
Use better names for non-root remotes.

### DIFF
--- a/src/com/jmibanez/tools/jmeter/ProxyObjectGraph.java
+++ b/src/com/jmibanez/tools/jmeter/ProxyObjectGraph.java
@@ -87,7 +87,8 @@ public class ProxyObjectGraph {
         // If instanceof Remote, replace with proxy
         if (instance instanceof Remote) {
             record.setRemoteReturned(true);
-            String instanceName = buildInstanceName((Remote) instance);
+            String instanceName = buildInstanceName((Remote) instance,
+                                                    record, path);
             DynamicStubProxyInvocationHandler handler =
                 new DynamicStubProxyInvocationHandler(instanceRegistry,
                                                       instance,

--- a/src/com/jmibanez/tools/jmeter/util/InstanceHandleFactory.java
+++ b/src/com/jmibanez/tools/jmeter/util/InstanceHandleFactory.java
@@ -1,11 +1,20 @@
 package com.jmibanez.tools.jmeter.util;
 
 import java.rmi.Remote;
+import com.jmibanez.tools.jmeter.MethodCallRecord;
 
 public class InstanceHandleFactory {
 
-    public static final String buildInstanceName(Remote instance) {
-        int stubHashCode = instance.hashCode();
-        return "remote_I" + stubHashCode;
+    public static final String buildInstanceName(final Remote instance,
+                                                 final MethodCallRecord record,
+                                                 final String path) {
+        String instancePath = path;
+        if (instancePath == null || "".equals(instancePath)) {
+            instancePath = "(return)";
+        }
+        return String.format("%1d %2s -> %3s",
+                             record.getIndex(),
+                             record.getMethod(),
+                             instancePath);
     }
 }


### PR DESCRIPTION
Generate better names for non-root remotes; in particular, names should be fairly stable across test recordings. The previous implementation which used the object's hash code to generate the name to be used in the registry could and did change across recordings. The implementation in this PR instead uses the method and object path which the non-root remote is coming from: a different recording would map to the same non-root remote name if the recording also had the same sequence of calls.