### PR TITLE
Regression: Singleton registry.

### DIFF
--- a/src/com/jmibanez/tools/jmeter/RMIRemoteObjectConfig.java
+++ b/src/com/jmibanez/tools/jmeter/RMIRemoteObjectConfig.java
@@ -49,8 +49,8 @@ public class RMIRemoteObjectConfig
 
     private static Log log = LogFactory.getLog(RMIRemoteObjectConfig.class);
 
-    private RemoteRegistry registry = null;
-    private Objenesis factory = null;
+    private ThreadLocal<RemoteRegistry> registry = new ThreadLocal<>();
+    private ThreadLocal<Objenesis> factory = new ThreadLocal<>();
 
     /**
      * Creates a new <code>RMIRemoteObjectConfig</code> instance.
@@ -79,8 +79,8 @@ public class RMIRemoteObjectConfig
     public void threadStarted() {
         log.info("Configuring remote stub registry for thread");
 
-        this.registry = new RemoteRegistry();
-        this.factory = new ObjenesisStd();
+        this.registry.set(new RemoteRegistry());
+        this.factory.set(new ObjenesisStd());
 
         JMeterContext jmctx = JMeterContextService.getContext();
         if(jmctx.getVariables().getObject(REMOTE_INSTANCES) == null) {
@@ -90,12 +90,12 @@ public class RMIRemoteObjectConfig
     }
 
     public void threadFinished() {
-        registry = null;
-        factory = null;
+        registry.remove();
+        factory.remove();
     }
 
     public Objenesis getFactory() {
-        return this.factory;
+        return this.factory.get();
     }
 
     public Remote getTarget(final String targetName) {
@@ -127,6 +127,6 @@ public class RMIRemoteObjectConfig
     }
 
     public RemoteRegistry getRegistry() {
-        return this.registry;
+        return this.registry.get();
     }
 }


### PR DESCRIPTION
Previously, in 9df2f1c9, we bound the registry to a thread local, so that each virtual user had their own registry. However, in our attempt to support multiple RMI Remote Object Config instances, we changed the registry back to a singleton, albeit created in the wrong place and wrong scope — we end up creating multiple registry instances, and inadvertently sharing the same instance anyway, where the registry created for the last thread started ends up being used, ending in a race where earlier threads may end up trying to fetch a remote that had been registered by the earlier thread, but isn't yet registered by the later thread.

So, return to using `ThreadLocal`s to contain the registry.