### PR TITLE
RMI Remote Object Config Global Scope

### DIFF
--- a/src/com/jmibanez/tools/jmeter/RMIRemoteObjectConfig.java
+++ b/src/com/jmibanez/tools/jmeter/RMIRemoteObjectConfig.java
@@ -16,7 +16,9 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.engine.util.NoThreadClone;
+import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.testelement.ThreadListener;
+import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.testelement.property.TestElementProperty;
@@ -44,17 +46,22 @@ import com.jmibanez.tools.jmeter.impl.SwitchingRemoteRegistry;
 public class RMIRemoteObjectConfig
     extends ConfigTestElement
     implements NoThreadClone,
+               TestStateListener,
                ThreadListener {
 
     public static final long serialVersionUID = 43339L;
 
     public static final String TARGET_RMI_NAME = "RmiRemoteObjectConfig.target_rmi_name";
+    public static final String IS_GLOBAL = "RmiRemoteObjectConfig.is_global";
     public static final String REMOTE_INSTANCES = "RMIRemoteObject.instances";
 
     private static Log log = LogFactory.getLog(RMIRemoteObjectConfig.class);
 
     private ThreadLocal<RemoteRegistry> registry = new ThreadLocal<>();
     private ThreadLocal<Objenesis> factory = new ThreadLocal<>();
+
+    private RemoteRegistry globalRegistry;
+    private Objenesis globalFactory;
 
     /**
      * Creates a new <code>RMIRemoteObjectConfig</code> instance.
@@ -80,11 +87,44 @@ public class RMIRemoteObjectConfig
         getRegistry().setArgumentTypes(targetName, methodName, argTypes);
     }
 
+    @Override
+    public void testStarted(String host) {
+        testStarted();
+    }
+
+    @Override
+    public void testStarted() {
+        if(isGlobal()) {
+            log.debug("RMI Remote Object Config element in global mode");
+            globalRegistry = new RemoteRegistry();
+            globalFactory = new ObjenesisStd();
+        }
+    }
+
+    @Override
+    public void testEnded(String host) {
+        testEnded();
+    }
+
+    @Override
+    public void testEnded() {
+        if(isGlobal()) {
+            log.debug("Stopping RMI Remote Object Config element in global mode");
+            globalRegistry = null;
+            globalFactory = null;
+        }
+    }
+
     public void threadStarted() {
         log.info("Configuring remote stub registry for thread");
 
-        this.registry.set(new RemoteRegistry());
-        this.factory.set(new ObjenesisStd());
+        if(!isGlobal()) {
+            this.registry.set(new RemoteRegistry());
+            this.factory.set(new ObjenesisStd());
+        }
+        else {
+            log.debug("Global registry is " + globalRegistry);
+        }
 
         JMeterContext jmctx = JMeterContextService.getContext();
         if(jmctx.getVariables().getObject(REMOTE_INSTANCES) == null) {
@@ -94,17 +134,33 @@ public class RMIRemoteObjectConfig
     }
 
     public void threadFinished() {
-        registry.remove();
-        factory.remove();
+        if(!isGlobal()) {
+            registry.remove();
+            factory.remove();
+        }
+    }
+
+    public boolean isGlobal() {
+        return getPropertyAsBoolean(IS_GLOBAL);
+    }
+
+    public void setGlobal(boolean isGlobal) {
+        setProperty(new BooleanProperty(IS_GLOBAL, isGlobal));
     }
 
     public Objenesis getFactory() {
-        return this.factory.get();
+        if(isGlobal()) {
+            return this.globalFactory;
+        }
+        else {
+            return this.factory.get();
+        }
     }
 
     public Remote getTarget(final String targetName) {
         assert (targetName != null && getRegistry().getTarget(targetName) != null): "Map should contain key";
 
+        log.debug("getRegistry() => " + getRegistry());
         Remote target = getRegistry().getTarget(targetName);
         if(target == null && targetName == null) {
             try {
@@ -131,6 +187,13 @@ public class RMIRemoteObjectConfig
     }
 
     public RemoteRegistry getRegistry() {
-        return this.registry.get();
+        if(isGlobal()) {
+            log.debug("getRegistry(): return global registry " + this.globalRegistry);
+            return this.globalRegistry;
+        }
+        else {
+            log.debug("getRegistry(): return thread local registry");
+            return this.registry.get();
+        }
     }
 }

--- a/src/com/jmibanez/tools/jmeter/RMIRemoteObjectConfig.java
+++ b/src/com/jmibanez/tools/jmeter/RMIRemoteObjectConfig.java
@@ -15,6 +15,7 @@ import java.rmi.Naming;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.jmeter.config.ConfigTestElement;
+import org.apache.jmeter.engine.util.NoThreadClone;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
@@ -42,7 +43,8 @@ import com.jmibanez.tools.jmeter.impl.SwitchingRemoteRegistry;
  */
 public class RMIRemoteObjectConfig
     extends ConfigTestElement
-    implements ThreadListener {
+    implements NoThreadClone,
+               ThreadListener {
 
     public static final long serialVersionUID = 43339L;
 

--- a/src/com/jmibanez/tools/jmeter/RMISampler.java
+++ b/src/com/jmibanez/tools/jmeter/RMISampler.java
@@ -16,6 +16,7 @@ import org.apache.commons.logging.LogFactory;
 import java.rmi.server.RemoteObject;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
+import org.apache.jmeter.engine.util.NoThreadClone;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.testelement.property.ObjectProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
@@ -42,7 +43,8 @@ import static com.jmibanez.tools.jmeter.util.ArgumentsUtil.unpackArgs;
  */
 public class RMISampler
     extends AbstractSampler
-    implements ThreadListener {
+    implements NoThreadClone,
+               ThreadListener {
 
     public static final long serialVersionUID = 6779L;
 

--- a/src/com/jmibanez/tools/jmeter/gui/RMIRemoteObjectConfigGUI.java
+++ b/src/com/jmibanez/tools/jmeter/gui/RMIRemoteObjectConfigGUI.java
@@ -12,6 +12,7 @@ import org.apache.jmeter.testelement.TestElement;
 import java.awt.BorderLayout;
 import javax.swing.Box;
 import com.jmibanez.tools.jmeter.RMIRemoteObjectConfig;
+import javax.swing.JCheckBox;
 import javax.swing.JTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -31,8 +32,10 @@ public class RMIRemoteObjectConfigGUI extends AbstractConfigGui {
     public static final long serialVersionUID = 98030L;
 
     private static final String TARGETNAME_FIELD = "targetRmiName";
+    private static final String ISGLOBAL_FIELD = "isGlobal";
 
     private JTextField targetRmiName;
+    private JCheckBox isGlobal;
 
     private RMIRemoteObjectConfig model;
 
@@ -58,6 +61,7 @@ public class RMIRemoteObjectConfigGUI extends AbstractConfigGui {
         if(element instanceof RMIRemoteObjectConfig) {
             model = (RMIRemoteObjectConfig) element;
             model.setTargetRmiName(targetRmiName.getText());
+            model.setGlobal(isGlobal.isSelected());
         }
     }
 
@@ -72,6 +76,7 @@ public class RMIRemoteObjectConfigGUI extends AbstractConfigGui {
         super.configure(e);
         model = (RMIRemoteObjectConfig) e;
         targetRmiName.setText(model.getTargetRmiName());
+        isGlobal.setSelected(model.isGlobal());
     }
 
     private void init() {
@@ -85,10 +90,14 @@ public class RMIRemoteObjectConfigGUI extends AbstractConfigGui {
         targetRmiName = new JTextField("", 40);
         targetRmiName.setName(TARGETNAME_FIELD);
 
-        JLabel label = new JLabel("Target RMI name");
-        label.setLabelFor(targetRmiName);
+        JLabel targetLabel = new JLabel("Target RMI name");
+        targetLabel.setLabelFor(targetRmiName);
 
-        config.add(label);
+        isGlobal = new JCheckBox("Shared across threads");
+        isGlobal.setName(ISGLOBAL_FIELD);
+
+        config.add(isGlobal);
+        config.add(targetLabel);
         config.add(targetRmiName);
 
         JPanel configPanel = new VerticalPanel();

--- a/test/com/jmibanez/tools/jmeter/RMIRemoteObjectConfigTest.java
+++ b/test/com/jmibanez/tools/jmeter/RMIRemoteObjectConfigTest.java
@@ -1,30 +1,170 @@
 package com.jmibanez.tools.jmeter;
 
 import java.rmi.Remote;
+import java.util.concurrent.CyclicBarrier;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
 import junit.framework.TestCase;
 
 import com.jmibanez.tools.jmeter.impl.RemoteRegistry;
 
 public class RMIRemoteObjectConfigTest extends TestCase {
 
-    private RemoteRegistry inst;
+    private RemoteRegistry registry;
+    private RMIRemoteObjectConfig remoteObjectConfig;
 
     @Override
     public void setUp()
         throws Exception {
-        inst = new RemoteRegistry();
+        registry = new RemoteRegistry();
+        remoteObjectConfig = new RMIRemoteObjectConfig();
     }
 
 
-    public void testRegisterNullInstance()
+    public void testRegisterNullRegistryance()
         throws Exception {
 
         StubDummy d = new StubDummy();
-        inst.registerRootRmiInstance(d);
+        registry.registerRootRmiInstance(d);
 
-        Remote r = inst.getTarget(null);
+        Remote r = registry.getTarget(null);
         assertNotNull(r);
         assertEquals(d, r);
+    }
+
+
+    public void testShouldHaveThreadLocalRegistry()
+        throws Exception {
+
+        final StubDummy d1 = new StubDummy();
+        final StubDummy d2 = new StubDummy();
+        final StubDummy d3 = new StubDummy();
+
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        final Remote[] targets = new Remote[2];
+
+        JMeterContext jmctx = JMeterContextService.getContext();
+        jmctx.setVariables(new JMeterVariables());
+
+        Thread t1 = new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        JMeterContext jmctx = JMeterContextService.getContext();
+                        jmctx.setVariables(new JMeterVariables());
+                        remoteObjectConfig.threadStarted();
+                        barrier.await();
+                        remoteObjectConfig.getRegistry().registerRootRmiInstance(d1);
+                        targets[0] = remoteObjectConfig.getTarget(null);
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        Thread t2 = new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        JMeterContext jmctx = JMeterContextService.getContext();
+                        jmctx.setVariables(new JMeterVariables());
+                        remoteObjectConfig.threadStarted();
+                        remoteObjectConfig.getRegistry().registerRootRmiInstance(d2);
+                        barrier.await();
+                        targets[1] = remoteObjectConfig.getTarget(null);
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+
+        remoteObjectConfig.threadStarted();
+        remoteObjectConfig.getRegistry().registerRootRmiInstance(d3);
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        assertNotNull(remoteObjectConfig.getTarget(null));
+        assertNotNull(targets[0]);
+        assertNotNull(targets[1]);
+
+        assertEquals(d3, remoteObjectConfig.getTarget(null));
+        assertEquals(d1, targets[0]);
+        assertEquals(d2, targets[1]);
+
+        assertSame(d3, remoteObjectConfig.getTarget(null));
+        assertSame(d1, targets[0]);
+        assertSame(d2, targets[1]);
+
+        assertNotSame(d3, targets[0]);
+        assertNotSame(d3, targets[1]);
+        assertNotSame(targets[0], targets[1]);
+    }
+
+    public void testShouldHaveGlobalRegistry()
+        throws Exception {
+
+        remoteObjectConfig.setGlobal(true);
+        remoteObjectConfig.testStarted();
+
+        final StubDummy d1 = new StubDummy();
+        final StubDummy d2 = new StubDummy();
+        final StubDummy d3 = new StubDummy();
+
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        final Remote[] targets = new Remote[2];
+
+        JMeterContext jmctx = JMeterContextService.getContext();
+        jmctx.setVariables(new JMeterVariables());
+
+        Thread t1 = new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        JMeterContext jmctx = JMeterContextService.getContext();
+                        jmctx.setVariables(new JMeterVariables());
+                        remoteObjectConfig.threadStarted();
+                        barrier.await();
+                        remoteObjectConfig.getRegistry().registerRootRmiInstance(d1);
+                        targets[0] = remoteObjectConfig.getTarget(null);
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        Thread t2 = new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        JMeterContext jmctx = JMeterContextService.getContext();
+                        jmctx.setVariables(new JMeterVariables());
+                        remoteObjectConfig.threadStarted();
+                        remoteObjectConfig.getRegistry().registerRootRmiInstance(d2);
+                        barrier.await();
+                        targets[1] = remoteObjectConfig.getTarget(null);
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+
+        remoteObjectConfig.threadStarted();
+        remoteObjectConfig.getRegistry().registerRootRmiInstance(d3);
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        assertNotNull(remoteObjectConfig.getTarget(null));
+        assertNotNull(targets[0]);
+        assertNotNull(targets[1]);
+
+        assertSame(remoteObjectConfig.getTarget(null), targets[0]);
+        assertSame(remoteObjectConfig.getTarget(null), targets[1]);
+        assertSame(targets[0], targets[1]);
     }
 
 


### PR DESCRIPTION
Allow a RMI Remote Object Config instance to be shared across threads.